### PR TITLE
fix: Prevents the creation of dialogues without elements

### DIFF
--- a/scripts/script_dialogue/MinecraftScriptDialogue/InputScriptDialogue.test.ts
+++ b/scripts/script_dialogue/MinecraftScriptDialogue/InputScriptDialogue.test.ts
@@ -14,6 +14,7 @@ import {
   inputSlider,
   inputText,
   inputToggle,
+  MissingElementsError,
 } from './InputScriptDialogue';
 import { newMockedInstance } from '../test/mock-helpers';
 
@@ -179,5 +180,14 @@ describe('InputScriptDialogue', () => {
     expect(ModalFormData).toHaveBeenCalledTimes(1);
     expect(response).toBeInstanceOf(DialogueRejectedResponse);
     expect((response as DialogueRejectedResponse).reason).toBe(FormRejectReason.MalformedResponse);
+  });
+
+  it('Test rejected dialogue without elements', async () => {
+    const player = mockPlayer();
+    const response = await inputScriptDialogue('my dialogue').open({ player });
+
+    expect(response).toBeInstanceOf(DialogueRejectedResponse);
+    expect((response as DialogueRejectedResponse).reason).toBe(undefined);
+    expect((response as DialogueRejectedResponse).exception).toBeInstanceOf(MissingElementsError);
   });
 });

--- a/scripts/script_dialogue/MinecraftScriptDialogue/InputScriptDialogue.ts
+++ b/scripts/script_dialogue/MinecraftScriptDialogue/InputScriptDialogue.ts
@@ -339,6 +339,10 @@ export class InputScriptDialogue<K extends string> extends ScriptDialogue<InputS
   }
 
   protected getShowable(_options: ResolvedShowDialogueOptions): Showable<ModalFormResponse> {
+    if (this.elements.length === 0) {
+      throw new MissingElementsError();
+    }
+
     const data = new ModalFormData();
 
     data.title(this.title);
@@ -421,5 +425,11 @@ export class InputScriptDialogueResponse<K extends string> {
 
   constructor(values: InputScriptDialogueResponseValues<K>) {
     this.values = values;
+  }
+}
+
+export class MissingElementsError extends Error {
+  constructor() {
+    super('Missing input elements');
   }
 }

--- a/scripts/script_dialogue/MinecraftScriptDialogue/MultiButtonScriptDialogue.test.ts
+++ b/scripts/script_dialogue/MinecraftScriptDialogue/MultiButtonScriptDialogue.test.ts
@@ -6,7 +6,12 @@ import {
   FormRejectReason,
   FormRejectError,
 } from '@minecraft/server-ui';
-import { ButtonDialogueResponse, DialogueCanceledResponse, DialogueRejectedResponse } from './ScriptDialogue';
+import {
+  ButtonDialogueResponse,
+  DialogueCanceledResponse,
+  DialogueRejectedResponse,
+  MissingButtonsException,
+} from './ScriptDialogue';
 import { mockPlayer } from '../test/server-utils';
 import { newMockedInstance } from '../test/mock-helpers';
 
@@ -205,5 +210,20 @@ describe('MultiButtonScriptDialogue', () => {
       .open({ player });
 
     expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('Without buttons its rejected', async () => {
+    const player = mockPlayer();
+    const response = await multiButtonScriptDialogue('hello world').open({ player });
+
+    expect(response).toBeInstanceOf(DialogueRejectedResponse);
+    expect((response as DialogueRejectedResponse).reason).toBe(undefined);
+    expect((response as DialogueRejectedResponse).exception).toBeInstanceOf(MissingButtonsException);
+
+    expect(player.runCommand).toHaveBeenCalledTimes(4);
+    expect(player.runCommand).toHaveBeenNthCalledWith(1, 'inputpermission set Steve camera disabled');
+    expect(player.runCommand).toHaveBeenNthCalledWith(2, `inputpermission set Steve movement disabled`);
+    expect(player.runCommand).toHaveBeenNthCalledWith(3, `inputpermission set Steve camera enabled`);
+    expect(player.runCommand).toHaveBeenNthCalledWith(4, `inputpermission set Steve movement enabled`);
   });
 });

--- a/scripts/script_dialogue/MinecraftScriptDialogue/MultiButtonScriptDialogue.ts
+++ b/scripts/script_dialogue/MinecraftScriptDialogue/MultiButtonScriptDialogue.ts
@@ -1,6 +1,7 @@
 import { ActionFormData, ActionFormResponse } from '@minecraft/server-ui';
 import {
   ButtonDialogueResponse,
+  MissingButtonsException,
   ResolvedShowDialogueOptions,
   ScriptDialogue,
   ScriptDialogueString,
@@ -111,6 +112,10 @@ export class MultiButtonDialogue<T extends string> extends ScriptDialogue<Button
   }
 
   protected getShowable(_options: ResolvedShowDialogueOptions): Showable<ActionFormResponse> {
+    if (this.buttons.length === 0) {
+      throw new MissingButtonsException();
+    }
+
     const formData = new ActionFormData();
 
     formData.title(this.title);

--- a/scripts/script_dialogue/MinecraftScriptDialogue/ScriptDialogue.ts
+++ b/scripts/script_dialogue/MinecraftScriptDialogue/ScriptDialogue.ts
@@ -230,3 +230,9 @@ export class ButtonDialogueResponse<T extends string> extends ScriptDialogueResp
     this.selected = selected;
   }
 }
+
+export class MissingButtonsException extends Error {
+  constructor() {
+    super('Missing buttons');
+  }
+}

--- a/scripts/script_dialogue/MinecraftScriptDialogue/index.ts
+++ b/scripts/script_dialogue/MinecraftScriptDialogue/index.ts
@@ -7,6 +7,7 @@ export {
   inputDropdown,
   inputScriptDialogue,
   InputScriptDialogueResponse,
+  MissingElementsError,
 } from './InputScriptDialogue';
 export {
   ButtonDialogueResponse,
@@ -16,6 +17,7 @@ export {
   DialogueRejectedResponse,
   ShowDialogueOptions,
   ScriptDialogueString,
+  MissingButtonsException,
 } from './ScriptDialogue';
 export { TRANSLATE } from './Utils';
 

--- a/scripts/script_dialogue/main.ts
+++ b/scripts/script_dialogue/main.ts
@@ -10,7 +10,7 @@ import {
   inputSlider,
   inputText,
   inputToggle,
-} from './MinecraftScriptDialogue/index';
+} from './MinecraftScriptDialogue';
 
 system.afterEvents.scriptEventReceive.subscribe(async (event) => {
   if (event.id === 'minescripters:test-script-dialogue-01' && event.sourceEntity instanceof Player) {


### PR DESCRIPTION
 - MultiButton must have at least a button
 - Input must have at least 1 element

Fixes #16