### PR TITLE
fix: Moved minecraft to peer-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,9 @@
     "": {
       "name": "@mine-scripters/minecraft-script-dialogue",
       "version": "1.1.1",
-      "dependencies": {
-        "@minecraft/server": "^1.7.0",
-        "@minecraft/server-ui": "1.1.0"
-      },
       "devDependencies": {
+        "@minecraft/server": "^1.7.0",
+        "@minecraft/server-ui": "1.1.0",
         "@rollup/plugin-terser": "^0.4.4",
         "@types/jest": "^29.5.11",
         "@types/node": "^20.10.6",
@@ -31,6 +29,10 @@
         "typedoc": "^0.25.6",
         "typescript": "^4.4.3",
         "vinyl-paths": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@minecraft/server": "^1.7.0",
+        "@minecraft/server-ui": "^1.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1386,12 +1388,14 @@
     "node_modules/@minecraft/common": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@minecraft/common/-/common-1.1.0.tgz",
-      "integrity": "sha512-stbUtINCXbcLNRlGNVX68xRC6ZYq3k3CYmfptwrCcPBEUjVOpVkSj3H4Y0qiSYB+1rVWv7DgiP7Uf9++50Ne5g=="
+      "integrity": "sha512-stbUtINCXbcLNRlGNVX68xRC6ZYq3k3CYmfptwrCcPBEUjVOpVkSj3H4Y0qiSYB+1rVWv7DgiP7Uf9++50Ne5g==",
+      "dev": true
     },
     "node_modules/@minecraft/server": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.7.0.tgz",
       "integrity": "sha512-4q9N3vdLZMAUxPo//bovimPbPLuPbHbQC507ZB2h++dqOGWUGnCcTXTNRg2zkBwMonAzWHONkUsVr5tsi9BHcg==",
+      "dev": true,
       "dependencies": {
         "@minecraft/common": "^1.1.0"
       }
@@ -1400,6 +1404,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-1.1.0.tgz",
       "integrity": "sha512-Gnf+GHjjT4VFoXEt7qjrfDRipDgc93YcXbgTmdPTQ5Og3DIRD003ahH97tGMZmeNdsB+ymvAquf+o2o9W2pDjw==",
+      "dev": true,
       "dependencies": {
         "@minecraft/server": "^1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "ts-jest": "^29.1.1",
     "typedoc": "^0.25.6",
     "typescript": "^4.4.3",
-    "vinyl-paths": "^5.0.0"
+    "vinyl-paths": "^5.0.0",
+    "@minecraft/server": "^1.7.0",
+    "@minecraft/server-ui": "1.1.0"
   },
   "scripts": {
     "build": "rollup -c",
@@ -39,9 +41,9 @@
     "enablemcloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-1958404141-86561845-1752920682-3514627264-368642714-62675701-733520436",
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@minecraft/server": "^1.7.0",
-    "@minecraft/server-ui": "1.1.0"
+    "@minecraft/server-ui": "^1.1.0"
   },
   "files": [
     "package.json",


### PR DESCRIPTION
Prevents from installing a specific version and relies on what the user wants to install.