### PR TITLE
fix: Adds all the versions to peerdeps to silence warns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
         "vinyl-paths": "^5.0.0"
       },
       "peerDependencies": {
-        "@minecraft/server": "^1.7.0",
-        "@minecraft/server-ui": "^1.1.0"
+        "@minecraft/server": ">=1.7.0 | >= 1.8.0 | >=1.9.0 | >=1.10.0",
+        "@minecraft/server-ui": ">=1.1.0 | >=1.2.0 "
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "enablemcpreviewloopback": "CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-346833251-474568803-887069379-4040235476"
   },
   "peerDependencies": {
-    "@minecraft/server": "^1.7.0",
-    "@minecraft/server-ui": "^1.1.0"
+    "@minecraft/server": "^1.7.0-0 || ^1.8.0-0 || ^1.9.0-0 || ^1.10.0-0",
+    "@minecraft/server-ui": "^1.1.0-0 || ^1.2.0-0"
   },
   "files": [
     "package.json",


### PR DESCRIPTION
 Since the pre-release version is used a lot, npm requires a more
 specific version instead of the stable version.